### PR TITLE
Add autoconf as a dep to resolve configure error

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -4,7 +4,7 @@
 export ZOPEN_TYPE="TARBALL"
 
 export ZOPEN_TARBALL_URL="https://ftp.gnu.org/gnu/texinfo/texinfo-6.8.tar.gz"
-export ZOPEN_TARBALL_DEPS="curl gzip make perl zoslib automake diffutils coreutils findutils"
+export ZOPEN_TARBALL_DEPS="curl gzip make perl zoslib m4 automake diffutils coreutils findutils autoconf"
 export ZOPEN_GIT_URL="https://git.savannah.gnu.org/git/texinfo.git"
 
 if [ "${ZOPEN_TYPE}x" = "GITx" ]; then


### PR DESCRIPTION
Resolves:
```
autom4te: FSUM7351 not found
aclocal-1.16: error: autom4te failed with exit status: 127
WARNING: 'aclocal-1.16' is missing on your system.
         You should only need it if you modified 'acinclude.m4' or
         '[configure.ac](http://configure.ac/)' or m4 files included by '[configure.ac](http://configure.ac/)'.
         The 'aclocal' program is part of the GNU Automake package:
         https://www.gnu.org/software/automake
         It also requires GNU Autoconf, GNU m4 and Perl in order to run:
         https://www.gnu.org/software/autoconf
         https://www.gnu.org/software/m4/
         https://www.perl.org/
```