### PR TITLE
fixed hang issue in texinfo

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -4,7 +4,7 @@
 export ZOPEN_TYPE="TARBALL"
 
 export ZOPEN_TARBALL_URL="https://ftp.gnu.org/gnu/texinfo/texinfo-6.8.tar.gz"
-export ZOPEN_TARBALL_DEPS="curl gzip make perl zoslib m4 automake diffutils coreutils findutils autoconf help2man"
+export ZOPEN_TARBALL_DEPS="curl gzip make perl zoslib m4 automake diffutils coreutils findutils autoconf help2man bash"
 export ZOPEN_GIT_URL="https://git.savannah.gnu.org/git/texinfo.git"
 
 if [ "${ZOPEN_TYPE}x" = "GITx" ]; then

--- a/patches/test-driver.patch
+++ b/patches/test-driver.patch
@@ -1,0 +1,13 @@
+diff --git a/build-aux/test-driver b/build-aux/test-driver
+index 9759384..80c50e1 100755
+--- a/build-aux/test-driver
++++ b/build-aux/test-driver
+@@ -106,7 +106,7 @@ trap "st=141; $do_exit" 13
+ trap "st=143; $do_exit" 15
+ 
+ # Test script is run here.
+-"$@" >$log_file 2>&1
++bash "$@" >$log_file 2>&1
+ estatus=$?
+ 
+ if test $enable_hard_errors = no && test $estatus -eq 99; then


### PR DESCRIPTION
The wait call in Init-test.inc in run_ginfo function called from malformed-split.sh test was causing it, on adding bash dependency in buildenv and calling test scripts using bash, from test-driver in build-aux dir, helped to resolve the issue.